### PR TITLE
Refactor Stage Module – Role-Based Authorization & Full Test Coverage

### DIFF
--- a/services/project-service/controllers/stage.controller.js
+++ b/services/project-service/controllers/stage.controller.js
@@ -1,4 +1,4 @@
-import { prisma } from "../config/database.js";
+// stage.controller.js
 import { validateRequest } from "../middleware/validate.middleware.js";
 import {
   createStageValidation,
@@ -7,47 +7,33 @@ import {
   deleteStageValidation,
   getStageByIdValidation,
 } from "../validators/stage.validator.js";
-import { StageDTO } from "../dtos/stage.dto.js";
+import {
+  getStagesService,
+  getStageByIdService,
+  createStageService,
+  updateStageService,
+  patchStageService,
+  deleteStageService,
+} from "../services/stage.service.js";
 
 /**
- * @desc Get all stages (with pagination)
+ * Get all stages with pagination and optional filtering.
  * @route GET /api/stages
  * @access Public
  */
 export const getStages = async (req, res) => {
   try {
-    const parsedPage = parseInt(req.query.page);
-    const parsedLimit = parseInt(req.query.limit);
-    const page = isNaN(parsedPage) || parsedPage < 1 ? 1 : parsedPage;
-    const limit = isNaN(parsedLimit) || parsedLimit < 1 ? 10 : parsedLimit;
-    const skip = (page - 1) * limit;
-
-    const [stages, totalCount] = await Promise.all([
-      prisma.stage.findMany({
-        skip,
-        take: limit,
-        include: { tasks: true }, // Include related tasks
-      }),
-      prisma.stage.count(),
-    ]);
-
-    const transformedStages = stages.map((stage) => new StageDTO(stage));
-
-    res.json({
-      data: transformedStages,
-      page,
-      limit,
-      totalCount,
-      totalPages: Math.ceil(totalCount / limit),
-    });
+    const stages = await getStagesService(req.user, req.query);
+    res.status(200).json(stages);
   } catch (error) {
-    console.error("Error fetching stages", error);
-    res.status(500).json({ error: "Internal server error" });
+    console.error("Error fetching stages:", error);
+    const statusCode = error.status || 500;
+    res.status(statusCode).json({ error: error.message });
   }
 };
 
 /**
- * @desc Get a stage by ID
+ * Get a stage by ID.
  * @route GET /api/stages/:id
  * @access Public
  */
@@ -57,65 +43,41 @@ export const getStageById = [
   async (req, res) => {
     try {
       const { id } = req.params;
-      const stage = await prisma.stage.findUnique({
-        where: { id },
-        include: { tasks: true }, // Ensures tasks are retrieved
-      });
-
-      if (!stage) {
-        return res.status(404).json({ error: "Stage not found" });
-      }
-
-      res.status(200).json(new StageDTO(stage)); // Ensures tasks are transformed into DTO
+      const stage = await getStageByIdService(req.user, id);
+      if (!stage) return res.status(404).json({ error: "Stage not found" });
+      res.status(200).json(stage);
     } catch (error) {
       console.error("Error fetching stage by ID:", error);
-      res.status(500).json({ error: "Internal server error" });
+      const statusCode = error.status || 500;
+      res.status(statusCode).json({ error: error.message });
     }
   },
 ];
 
 /**
- * @desc Create a new stage
+ * Create a new stage.
  * @route POST /api/stages
- * @access Public
+ * @access Protected (Admins and Managers)
  */
 export const createStage = [
   createStageValidation,
   validateRequest,
   async (req, res) => {
     try {
-      let { name, position, color, projectId } = req.body;
-      const normalizedName = name.toLowerCase();
-
-      const stage = await prisma.stage.create({
-        data: {
-          name: normalizedName,
-          position,
-          color,
-          projectId,
-        },
-        include: { tasks: true }, // Ensure tasks are included if needed
-      });
-
-      res.status(201).json({
-        message: "Stage created successfully",
-        stage: new StageDTO(stage),
-      });
+      const stage = await createStageService(req.user, req.body);
+      res.status(201).json({ message: "Stage created successfully", stage });
     } catch (error) {
-      if (error.code === "P2002") {
-        return res.status(409).json({
-          error: "A stage with this name already exists for this project",
-        });
-      }
-      res.status(500).json({ error: "Internal server error" });
+      console.error("❌ Error creating stage:", error);
+      const statusCode = error.status || 500;
+      res.status(statusCode).json({ error: error.message });
     }
   },
 ];
 
 /**
- * @desc Update a stage (PUT)
+ * Fully update a stage.
  * @route PUT /api/stages/:id
- * @access Public
+ * @access Protected (Admins and Managers with proper authorization)
  */
 export const updateStage = [
   updateStageValidation,
@@ -123,37 +85,20 @@ export const updateStage = [
   async (req, res) => {
     try {
       const { id } = req.params;
-      let { name, position, color } = req.body;
-
-      const updateData = { position, color };
-      if (name) {
-        updateData.name = name.toLowerCase();
-      }
-
-      const stage = await prisma.stage.update({
-        where: { id },
-        data: updateData,
-      });
-
-      res.status(200).json({
-        message: "Stage updated successfully",
-        stage: new StageDTO(stage),
-      });
+      const stage = await updateStageService(req.user, id, req.body);
+      res.status(200).json({ message: "Stage updated successfully", stage });
     } catch (error) {
-      if (error.code === "P2002") {
-        return res.status(409).json({
-          error: "A stage with this name already exists for this project",
-        });
-      }
-      res.status(500).json({ error: "Internal server error" });
+      console.error("❌ Error updating stage:", error);
+      const statusCode = error.status || 500;
+      res.status(statusCode).json({ error: error.message });
     }
   },
 ];
 
 /**
- * @desc Partially update a stage (PATCH)
+ * Partially update a stage.
  * @route PATCH /api/stages/:id
- * @access Public
+ * @access Protected (Admins and Managers with proper authorization)
  */
 export const patchStage = [
   patchStageValidation,
@@ -161,48 +106,20 @@ export const patchStage = [
   async (req, res) => {
     try {
       const { id } = req.params;
-      const updateData = {};
-
-      Object.entries(req.body).forEach(([key, value]) => {
-        if (value !== undefined) {
-          updateData[key] = value;
-        }
-      });
-
-      if (Object.keys(updateData).length === 0) {
-        return res
-          .status(400)
-          .json({ error: "No valid fields provided for update" });
-      }
-
-      if (updateData.name) {
-        updateData.name = updateData.name.toLowerCase();
-      }
-
-      const stage = await prisma.stage.update({
-        where: { id },
-        data: updateData,
-      });
-
-      res.status(200).json({
-        message: "Stage updated successfully",
-        stage: new StageDTO(stage),
-      });
+      const stage = await patchStageService(req.user, id, req.body);
+      res.status(200).json({ message: "Stage updated successfully", stage });
     } catch (error) {
-      if (error.code === "P2002") {
-        return res.status(409).json({
-          error: "A stage with this name already exists for this project",
-        });
-      }
-      res.status(500).json({ error: "Internal server error" });
+      console.error("❌ Error patching stage:", error);
+      const statusCode = error.status || 500;
+      res.status(statusCode).json({ error: error.message });
     }
   },
 ];
 
 /**
- * @desc Delete a stage
+ * Delete a stage.
  * @route DELETE /api/stages/:id
- * @access Public
+ * @access Protected (Admins and Managers who created the associated project)
  */
 export const deleteStage = [
   deleteStageValidation,
@@ -210,12 +127,12 @@ export const deleteStage = [
   async (req, res) => {
     try {
       const { id } = req.params;
-      await prisma.stage.delete({ where: { id } });
-
-      res.status(200).json({ message: "Stage deleted successfully" });
+      const response = await deleteStageService(req.user, id);
+      res.status(200).json(response);
     } catch (error) {
-      console.error("Error deleting stage:", error);
-      res.status(500).json({ error: "Internal server error" });
+      console.error("❌ Error deleting stage:", error);
+      const statusCode = error.status || 500;
+      res.status(statusCode).json({ error: error.message });
     }
   },
 ];

--- a/services/project-service/docs/TEST_SCENARIOS.md
+++ b/services/project-service/docs/TEST_SCENARIOS.md
@@ -1,27 +1,40 @@
-# 🚀 Project Module – User Stories & Test Scenarios
+# 🚀 Project & Stage Modules – User Stories & Test Scenarios
 
-This document describes the main user stories, acceptance criteria, and test scenarios for the **Project** module. This module handles the creation, retrieval, updating (both full and partial), and deletion of projects with role‐based access control.
+This document describes the main user stories, acceptance criteria, and test scenarios for the **Project** and **Stage** modules. Both modules leverage role‐based access control and provide CRUD operations with validations, filters, and sorting.
 
 ---
 
 ## Table of Contents
 
-- [User Stories](#user-stories)
-  - [1. View Projects](#1-view-projects)
-  - [2. Create a Project](#2-create-a-project)
-  - [3. Update a Project](#3-update-a-project)
-  - [4. Delete a Project](#4-delete-a-project)
-- [Test Scenarios](#test-scenarios)
-  - [Service Layer Tests](#service-layer-tests)
-  - [Controller Layer Tests](#controller-layer-tests)
+- [Project Module](#project-module)
+  - [User Stories](#user-stories-project)
+    - [1. View Projects](#1-view-projects)
+    - [2. Create a Project](#2-create-a-project)
+    - [3. Update a Project](#3-update-a-project)
+    - [4. Delete a Project](#4-delete-a-project)
+  - [Test Scenarios](#test-scenarios-project)
+    - [Service Layer Tests](#service-layer-tests-project)
+    - [Controller Layer Tests](#controller-layer-tests-project)
+- [Stage Module](#stage-module)
+  - [User Stories](#user-stories-stage)
+    - [1. View Stages](#1-view-stages)
+    - [2. Create a Stage](#2-create-a-stage)
+    - [3. Update a Stage](#3-update-a-stage)
+    - [4. Delete a Stage](#4-delete-a-stage)
+  - [Test Scenarios](#test-scenarios-stage)
+    - [Service Layer Tests](#service-layer-tests-stage)
+    - [Controller Layer Tests](#controller-layer-tests-stage)
 - [How to Run Tests](#how-to-run-tests)
 - [Conclusion](#conclusion)
 
 ---
 
-## User Stories
+## Project Module
 
-### 1. View Projects :bar_chart:
+### User Stories (Project)
+
+#### 1. View Projects
+
 - **As an Admin,** I want to view all projects with pagination, filters, and sorting so that I can manage the overall portfolio.
   - **Acceptance Criteria:**
     - Admins can view all projects.
@@ -33,20 +46,22 @@ This document describes the main user stories, acceptance criteria, and test sce
   - **Acceptance Criteria:**
     - Employees see only projects where their ID is present in the `employeeIds` array.
 
-- **As a Manager,** I want to view projects that I manage, have created, or where I am assigned so that I can update them if needed.
+- **As a Manager,** I want to view projects that I manage, have created, or where I am assigned so that I can update or delete them if needed (with restrictions).
   - **Acceptance Criteria:**
     - Managers see projects where they are the manager, the creator, or are assigned as an employee.
     - **Update:** Only projects that I manage or that I created are available for update.
     - **Deletion:** Only projects that I **created** are available for deletion.
 
-### 2. Create a Project :sparkles:
+#### 2. Create a Project
+
 - **As an Admin or Manager,** I want to create a new project so that I can add new initiatives.
   - **Acceptance Criteria:**
     - Only Admins and Managers can create projects.
     - The project name is normalized to lowercase.
-    - Duplicate project names are rejected with an appropriate error.
+    - Duplicate project names are rejected with an appropriate error (e.g., **409**).
 
-### 3. Update a Project :pencil2:
+#### 3. Update a Project
+
 - **As an Admin or Manager,** I want to update an existing project so that I can change its details.
   - **Acceptance Criteria:**
     - **Full Update (PUT):** Replaces all fields; if the project name is provided, it is converted to lowercase.
@@ -56,7 +71,8 @@ This document describes the main user stories, acceptance criteria, and test sce
     - If the project is not found, a **404** error is returned.
     - Duplicate project name errors return **409**, and generic errors return **500**.
 
-### 4. Delete a Project :wastebasket:
+#### 4. Delete a Project
+
 - **As an Admin or Manager,** I want to delete a project so that I can remove projects that are no longer needed.
   - **Acceptance Criteria:**
     - Only Admins can delete any project, while Managers can delete **only projects they created**.
@@ -66,77 +82,202 @@ This document describes the main user stories, acceptance criteria, and test sce
 
 ---
 
-## Test Scenarios
+### Test Scenarios (Project)
 
-### Service Layer Tests
+#### Service Layer Tests (Project)
 
-#### getProjectsService
-- **Success Cases:**
-  - Returns projects successfully when projects exist.
-  - Returns an empty result (with `totalCount = 0` and `totalPages = 0`) when no projects are found.
-  - Applies the **name** filter correctly (case-insensitive search).
-  - Applies the **description** filter correctly.
-  - Applies a valid **createdAt** filter (projects within the specified day).
-  - Uses provided sort options if valid; defaults to `"createdAt"` and `"desc"` if not.
-  - **Pagination Defaults:**  
-    - When `page` or `limit` are non-numeric or less than 1, defaults to `page = 1` and `limit = 10`.
-    - When valid numeric values are provided (e.g., `page = 2, limit = 5`), those values are used.
-- **Error Cases:**
-  - If the error object has code `"P2025"`, the service rejects with **403**.
-  - Generic errors (plain Error objects) are caught and rejected with **500**.
+1. **`getProjectsService`**
+   - **Success Cases:**
+     - Returns projects successfully when projects exist.
+     - Returns empty result when no projects found (`totalCount = 0`, `totalPages = 0`).
+     - Applies the **name** filter (case-insensitive).
+     - Applies the **description** filter.
+     - Applies **createdAt** filter to get projects within a specific day.
+     - Sorts properly or defaults to `createdAt desc` if invalid sort is provided.
+     - Pagination defaults to `page = 1` and `limit = 10` for invalid inputs; uses provided page/limit if valid.
+   - **Error Cases:**
+     - If Prisma error code is `"P2025"`, reject with **403**.
+     - All other errors reject with **500**.
 
-#### getProjectByIdService
-- **Success Case:**
-  - Returns the project (wrapped in a ProjectDTO) with its associated stages and tasks.
-- **Error Cases:**
-  - If no project is found by filters but exists in the DB, rejects with **403**.
-  - If the project does not exist, rejects with **404**.
-  - Generic errors result in a **500** rejection.
+2. **`getProjectByIdService`**
+   - **Success Case:** Returns the project (with its stages and tasks) as a `ProjectDTO`.
+   - **Error Cases:**
+     - If the user doesn't have permission but the project exists, reject with **403**.
+     - If the project is not found in the database, reject with **404**.
+     - Generic errors => **500**.
 
-### Controller Layer Tests
+3. **`createProjectService`**
+   - **Success Case:** Admin or Manager creates a project; name is lowercased; returns a `ProjectDTO`.
+   - **Error Cases:**
+     - If user is not Admin/Manager => **403**.
+     - Duplicate name => **409**.
+     - Generic => **500**.
 
-For each controller endpoint (GET, POST, PUT, PATCH, DELETE):
+4. **`updateProjectService`** / **`patchProjectService`**
+   - **Success Cases:**
+     - Full update or partial update successfully modifies and returns a `ProjectDTO`.
+     - Name, if present, is lowercased.
+   - **Error Cases:**
+     - No valid fields for patch => **400**.
+     - Unauthorized => **403**.
+     - Not found => **404**.
+     - Duplicate name => **409**.
+     - Generic => **500**.
+
+5. **`deleteProjectService`**
+   - **Success Case:** Admin can delete any project; Manager can delete only projects they created.
+   - **Error Cases:**
+     - Not found => **404**.
+     - Unauthorized => **403**.
+     - Generic => **500**.
+
+#### Controller Layer Tests (Project)
 
 - **Success Paths:**  
-  - The controller calls the corresponding service method and responds with the expected status (e.g., 200, 201) and payload.
-
+  - Controller responds with **200** (GET), **201** (POST), or **200** (PUT/PATCH/DELETE) on valid service responses.
 - **Error Handling:**  
-  - When the service rejects with a custom error (i.e., with a `status`), the controller uses that status and error message.
-  - When the service rejects with a plain Error (without a `status`), the controller falls back to **500** and uses the error’s message.
+  - For custom errors with a `status` field, uses that status and error message.
+  - For plain `Error` objects, uses **500** as fallback.
+
+---
+
+## Stage Module
+
+### User Stories (Stage)
+
+#### 1. View Stages
+
+- **As an Admin,** I want to view all stages (with optional filters, pagination, and sorting) so that I can see progress across all projects.
+  - **Acceptance Criteria:**
+    - Admins can see all stages.
+    - Can filter stages by **name**, **position**, **color** (hex code), and **projectId**.
+    - Can sort by **name**, **position**, **createdAt**, or **updatedAt**.
+    - Pagination defaults to `page = 1` and `limit = 10` if invalid values are provided.
+
+- **As a Manager,** I want to view only the stages of projects that I manage, created, or am assigned to so that I can update them if needed.
+  - **Acceptance Criteria:**
+    - Managers can see stages belonging to any project where `managerId` or `createdBy` is the Manager’s ID, or the manager is assigned as an employee.
+    - Sorting and pagination function the same as for Admin.
+
+- **As an Employee,** I only want to see stages that belong to projects in which I am an assigned employee so that I can track relevant tasks.
+  - **Acceptance Criteria:**
+    - Employees see only stages from their assigned projects.
+
+#### 2. Create a Stage
+
+- **As an Admin or Manager,** I want to create a new stage for a project so that the workflow can be defined.
+  - **Acceptance Criteria:**
+    - Only Admins and Managers can create stages.
+    - Stage name is lowercased.
+    - If a stage with the same name already exists for the same project, reject with **409**.
+    - Color must be a valid hex code.
+
+#### 3. Update a Stage
+
+- **As an Admin or Manager,** I want to update an existing stage so that I can rename it, reorder it, or change its color.
+  - **Acceptance Criteria:**
+    - **Full Update (PUT):** Replaces all fields (name is lowercased if present).
+    - **Partial Update (PATCH):** Only specified fields are changed, ignoring undefined. Name is lowercased if present.
+    - If no valid fields are provided (PATCH), return **400**.
+    - Unauthorized => **403**.
+    - Stage not found => **404**.
+    - Duplicate name => **409**.
+    - Generic => **500**.
+
+#### 4. Delete a Stage
+
+- **As an Admin or Manager,** I want to delete a stage so that I can remove unnecessary workflow steps.
+  - **Acceptance Criteria:**
+    - Admin can delete any stage.
+    - Manager can delete a stage only if they **created** the associated project.
+    - Not found => **404**.
+    - Unauthorized => **403**.
+    - Generic => **500**.
+
+---
+
+### Test Scenarios (Stage)
+
+#### Service Layer Tests (Stage)
+
+1. **`getStagesService`**
+   - **Success Cases:**
+     - Returns stages successfully (includes tasks if required).
+     - Filters by **name**, **position**, **color**, and **projectId**.
+     - Applies role-based filters:
+       - Admin sees all.
+       - Manager sees only stages from managed/created/assigned projects.
+       - Employee sees only stages from assigned projects.
+     - Sorting by **allowed fields** or default to `createdAt desc`.
+     - Pagination defaults to `(page=1, limit=10)` if invalid.
+   - **Error Cases:**
+     - If error code is `"P2025"`, reject with **403**.
+     - Generic => **500**.
+
+2. **`getStageByIdService`**
+   - **Success Cases:**
+     - Returns the stage and its tasks if the user has access.
+   - **Error Cases:**
+     - If the user doesn’t have permission but the stage exists => **403**.
+     - Stage not found => **404**.
+     - Generic => **500**.
+
+3. **`createStageService`**
+   - **Success Case:** Admin/Manager creates a stage (name lowercased). Returns a `StageDTO`.
+   - **Error Cases:**
+     - Employee attempts to create => **403**.
+     - Duplicate name => **409**.
+     - Generic => **500**.
+
+4. **`updateStageService`** / **`patchStageService`**
+   - **Success Cases:**
+     - Updates the stage fully or partially. Name is lowercased if present.
+     - If partial update has no valid fields => **400**.
+   - **Error Cases:**
+     - Unauthorized => **403** (manager does not match project).
+     - Stage not found => **404**.
+     - Duplicate name => **409**.
+     - Generic => **500**.
+
+5. **`deleteStageService`**
+   - **Success Case:** Admin can delete any stage; Manager can delete if they created the project.
+   - **Error Cases:**
+     - Stage not found => **404**.
+     - Unauthorized => **403**.
+     - Generic => **500**.
+
+#### Controller Layer Tests (Stage)
+
+- **Success Paths:**  
+  - Controller calls the corresponding service and responds with 200 (for GET, PUT, PATCH, DELETE) or 201 (for POST) plus the JSON data.
+- **Error Handling:**  
+  - If the service returns a custom `{ status: ..., message: ... }`, the controller uses that status.  
+  - If the service throws a plain Error, the controller uses 500.
 
 ---
 
 ## How to Run Tests
 
-- **Run All Tests:**  
-  ```bash
-  npm run test
-  ```
+```bash
+# Run all tests
+npm run test
 
-- **Run a Specific Folder or Test:**
-  ```bash
-  npm run test ./tests/unit/controllers/project.controller.test.js
-  ```
+# Run a specific test file
+npm run test ./tests/unit/services/project.service.test.js
 
-- **Run Tests with Coverage:**
-  ```bash
-  npm run test:coverage
-  ```
+# Run tests with coverage
+npm run test:coverage
+```
 
 ---
 
 ## Conclusion
 
-This documentation provides an overview of the user stories and detailed test scenarios for the Project module. It ensures that all branches in the service and controller logic are thoroughly covered, including:
+This documentation provides comprehensive user stories and test scenarios for both the Project and Stage modules. It outlines:
 
-- **Default Pagination Logic:**
-  - If invalid values are provided, the service defaults to `page = 1` and `limit = 10`.
+- **Role-Based Access Control** for Admin, Manager, and Employee roles.
+- **CRUD Operations** with robust checks for duplicates, invalid data, unauthorized access, and pagination defaults.
+- **Error Handling** with clear status codes (**400, 403, 404, 409, 500**).
+- **Testing Strategies** covering both the service layer and controller layer, ensuring coverage of success paths and error paths alike.
 
-- **Role-Based Authorization:**
-  - Only Admins and Managers (with specific restrictions) can create, update, and delete projects.
-  - For deletion, Managers can delete only the projects they created.
-
-- **Error Handling:**
-  - Proper error responses are returned with status codes **403, 404, 409, or 500** as appropriate.
-
-These test scenarios and user stories serve as a guide for future development and maintenance, ensuring the module's robustness and reliability.
+By following these guidelines, teams can maintain consistent behaviors, reduce regressions, and streamline development for both modules.

--- a/services/project-service/routes/stage.routes.js
+++ b/services/project-service/routes/stage.routes.js
@@ -23,7 +23,7 @@ const router = express.Router();
  * /api/stages:
  *   get:
  *     summary: Retrieve all stages with pagination
- *     description: Fetches a paginated list of stages. No filters are applied.
+ *     description: Fetches a paginated list of stages. Stages are filtered based on the user's role.
  *     tags: [Stages]
  *     security:
  *       - BearerAuth: []
@@ -42,7 +42,7 @@ const router = express.Router();
  *         description: The number of stages per page.
  *     responses:
  *       200:
- *         description: A list of stages retrieved successfully.
+ *         description: A paginated list of stages retrieved successfully.
  *         content:
  *           application/json:
  *             schema:
@@ -67,7 +67,7 @@ const router = express.Router();
  *                         example: "#FF5733"
  *                       projectId:
  *                         type: string
- *                         example: "p1q2r3s4-5678-9abc-defg-hijklmnopqrs"
+ *                         example: "d7d6f728-8e2d-4b8a-a349-fd1a534b7e5a"
  *                       createdAt:
  *                         type: string
  *                         format: date-time
@@ -93,7 +93,7 @@ const router = express.Router();
  *       401:
  *         description: Unauthorized, token required.
  *       403:
- *         description: User is not verified.
+ *         description: User is not verified or not authorized.
  *       500:
  *         description: Internal server error.
  */
@@ -104,7 +104,7 @@ router.get("/", authMiddleware, getStages);
  * /api/stages/{id}:
  *   get:
  *     summary: Get a stage by ID
- *     description: Fetches details of a specific stage.
+ *     description: Fetches details of a specific stage, including its tasks.
  *     tags: [Stages]
  *     security:
  *       - BearerAuth: []
@@ -123,7 +123,7 @@ router.get("/", authMiddleware, getStages);
  *       401:
  *         description: Unauthorized, token required.
  *       403:
- *         description: User is not verified.
+ *         description: User is not verified or not authorized to view the stage.
  *       404:
  *         description: Stage not found.
  *       500:
@@ -136,7 +136,7 @@ router.get("/:id", authMiddleware, getStageById);
  * /api/stages:
  *   post:
  *     summary: Create a new stage
- *     description: Creates a new stage within a project.
+ *     description: Creates a new stage within a project. Only Admins and Managers can create stages.
  *     tags: [Stages]
  *     security:
  *       - BearerAuth: []
@@ -224,7 +224,7 @@ router.post("/", authMiddleware, createStage);
  *       401:
  *         description: Unauthorized, token required.
  *       403:
- *         description: User is not verified.
+ *         description: User is not verified or not authorized to update the stage.
  *       404:
  *         description: Stage not found.
  *       409:
@@ -271,11 +271,11 @@ router.put("/:id", authMiddleware, updateStage);
  *       200:
  *         description: Stage updated successfully.
  *       400:
- *         description: Invalid or expired token.
+ *         description: Invalid or expired token, or no valid fields provided for update.
  *       401:
  *         description: Unauthorized, token required.
  *       403:
- *         description: User is not verified.
+ *         description: User is not verified or not authorized to update the stage.
  *       404:
  *         description: Stage not found.
  *       409:
@@ -290,7 +290,7 @@ router.patch("/:id", authMiddleware, patchStage);
  * /api/stages/{id}:
  *   delete:
  *     summary: Delete a stage
- *     description: Removes a stage from a project.
+ *     description: Removes a stage from a project. Only Admins can delete any stage; Managers can delete only stages from projects they created.
  *     tags: [Stages]
  *     security:
  *       - BearerAuth: []
@@ -304,12 +304,23 @@ router.patch("/:id", authMiddleware, patchStage);
  *     responses:
  *       200:
  *         description: Stage deleted successfully.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: integer
+ *                   example: 200
+ *                 message:
+ *                   type: string
+ *                   example: "Stage deleted successfully"
  *       400:
  *         description: Invalid or expired token.
  *       401:
  *         description: Unauthorized, token required.
  *       403:
- *         description: User is not verified.
+ *         description: User is not verified or not authorized to delete the stage.
  *       404:
  *         description: Stage not found.
  *       500:

--- a/services/project-service/services/stage.service.js
+++ b/services/project-service/services/stage.service.js
@@ -1,0 +1,396 @@
+// stage.service.js
+import { prisma } from "../config/database.js";
+import { StageDTO } from "../dtos/stage.dto.js";
+
+/**
+ * Generate dynamic filter conditions based on query parameters.
+ * @param {Object} query - Query parameters from the request.
+ * @returns {Object} - Filter conditions for Prisma query.
+ */
+const getDynamicFilters = (query) => {
+  const filters = {};
+  if (query.name) {
+    filters.name = { contains: query.name, mode: "insensitive" };
+  }
+  if (query.position) {
+    filters.position = parseInt(query.position);
+  }
+  if (query.color) {
+    filters.color = { equals: query.color };
+  }
+  if (query.projectId) {
+    filters.projectId = query.projectId;
+  }
+  return filters;
+};
+
+/**
+ * Generate sorting options for stage queries.
+ * @param {Object} query - Query parameters from the request.
+ * @returns {Object} - Sorting options for Prisma query.
+ */
+const getSortingOptions = (query) => {
+  const allowedFields = ["name", "position", "createdAt", "updatedAt"];
+  const sortField = allowedFields.includes(query.sortField)
+    ? query.sortField
+    : "createdAt";
+  const sortOrder = query.sortOrder === "asc" ? "asc" : "desc";
+  return { [sortField]: sortOrder };
+};
+
+/**
+ * Generate role-based filter for GET operations on stages.
+ * ROLE_EMPLOYEE: stages from projects where employeeIds contains user.id.
+ * ROLE_MANAGER: stages from projects where managerId, createdBy, or employeeIds match user.id.
+ * ROLE_ADMIN: no additional filter.
+ * @param {Object} user - The user object.
+ * @returns {Object} - Filter object for stage queries.
+ */
+const getStageRoleBasedFilter = (user) => {
+  if (user.role === "ROLE_EMPLOYEE") {
+    return { Project: { employeeIds: { has: user.id } } };
+  } else if (user.role === "ROLE_MANAGER") {
+    return {
+      OR: [
+        { Project: { managerId: user.id } },
+        { Project: { createdBy: user.id } },
+        { Project: { employeeIds: { has: user.id } } },
+      ],
+    };
+  }
+  return {}; // ROLE_ADMIN: no filter.
+};
+
+/**
+ * Authorize stage modification (update or patch) based on user role.
+ * ROLE_ADMIN: allowed.
+ * ROLE_MANAGER: allowed if the related project's managerId or createdBy matches user.id.
+ * @param {Object} user - The user performing the operation.
+ * @param {string} id - The stage ID.
+ * @param {Object} logConfig - Custom logging messages.
+ * @returns {Promise<Object>} - Resolves with the stage if authorized.
+ */
+const authorizeStageModification = async (user, id, logConfig) => {
+  const stage = await prisma.stage.findUnique({
+    where: { id },
+    include: { Project: true },
+  });
+  if (!stage) {
+    return Promise.reject({ status: 404, message: "Stage not found" });
+  }
+  if (user.role === "ROLE_ADMIN") {
+    console.log(logConfig.adminLog.replace("{id}", id));
+    return stage;
+  }
+  if (
+    user.role === "ROLE_MANAGER" &&
+    (stage.Project.managerId === user.id || stage.Project.createdBy === user.id)
+  ) {
+    console.log(logConfig.managerLog.replace("{id}", id));
+    return stage;
+  }
+  console.warn(logConfig.unauthorizedLog.replace("{id}", id));
+  return Promise.reject({
+    status: 403,
+    message: logConfig.unauthorizedMessage,
+  });
+};
+
+/**
+ * Authorize stage deletion based on user role.
+ * ROLE_ADMIN: allowed.
+ * ROLE_MANAGER: allowed only if the stage’s related project was created by the user.
+ * @param {Object} user - The user performing the deletion.
+ * @param {string} id - The stage ID.
+ * @returns {Promise<Object>} - Resolves with the stage if authorized.
+ */
+const authorizeStageDeletion = async (user, id) => {
+  const stage = await prisma.stage.findUnique({
+    where: { id },
+    include: { Project: true },
+  });
+  if (!stage) {
+    return Promise.reject({ status: 404, message: "Stage not found" });
+  }
+  if (user.role === "ROLE_ADMIN") {
+    console.log(`✅ Admin deleting stage: ${id}`);
+    return stage;
+  }
+  if (user.role === "ROLE_MANAGER" && stage.Project.createdBy === user.id) {
+    console.log(`Manager deleting stage they created: ${id}`);
+    return stage;
+  }
+  console.warn(`Access denied: User not authorized to delete stage ${id}`);
+  return Promise.reject({
+    status: 403,
+    message: "Access denied: You do not have permission to delete this stage",
+  });
+};
+
+/**
+ * Retrieve a paginated list of stages based on filters, sorting, and role-based authorization.
+ * @param {Object} user - The user making the request.
+ * @param {Object} query - Query parameters for filtering, pagination, and sorting.
+ * @returns {Promise<Object>} - Paginated stages data.
+ */
+export const getStagesService = async (user, query) => {
+  const parsedPage = parseInt(query.page);
+  const parsedLimit = parseInt(query.limit);
+  const page = isNaN(parsedPage) || parsedPage < 1 ? 1 : parsedPage;
+  const limit = isNaN(parsedLimit) || parsedLimit < 1 ? 10 : parsedLimit;
+  const skip = (page - 1) * limit;
+
+  const where = {
+    ...getStageRoleBasedFilter(user),
+    ...getDynamicFilters(query),
+  };
+
+  const orderBy = getSortingOptions(query);
+
+  try {
+    const [stages, totalCount] = await Promise.all([
+      prisma.stage.findMany({
+        where,
+        skip,
+        take: limit,
+        orderBy,
+        include: { tasks: true, Project: true },
+      }),
+      prisma.stage.count({ where }),
+    ]);
+
+    if (totalCount === 0) {
+      console.warn("No stages found with filters:", where);
+      return {
+        data: [],
+        page,
+        limit,
+        totalCount: 0,
+        totalPages: 0,
+      };
+    }
+
+    return {
+      data: stages.map((stage) => new StageDTO(stage)),
+      page,
+      limit,
+      totalCount,
+      totalPages: Math.ceil(totalCount / limit),
+    };
+  } catch (error) {
+    console.error("Error fetching stages:", error);
+    if (error.code === "P2025") {
+      return Promise.reject({
+        status: 403,
+        message: "Access denied: You do not have permission to view stages",
+      });
+    }
+    return Promise.reject({ status: 500, message: "Internal server error" });
+  }
+};
+
+/**
+ * Retrieve a single stage by its ID with associated tasks.
+ * @param {Object} user - The user making the request.
+ * @param {string} id - The stage ID.
+ * @returns {Promise<StageDTO>} - The stage data transfer object.
+ */
+export const getStageByIdService = async (user, id) => {
+  try {
+    const where = { id, ...getStageRoleBasedFilter(user) };
+
+    console.log("🔍 Debug: Stage role-based filter", where);
+
+    const stage = await prisma.stage.findFirst({
+      where,
+      include: { tasks: true, Project: true },
+    });
+
+    if (!stage) {
+      console.log("Debug: No stage found with filters", where);
+      const existingStage = await prisma.stage.findUnique({
+        where: { id },
+        select: { id: true },
+      });
+      if (existingStage) {
+        console.warn("Access denied: User does not have permission");
+        return Promise.reject({
+          status: 403,
+          message: "Access denied: You do not have permission to view this stage",
+        });
+      } else {
+        console.warn("Stage not found in database");
+        return Promise.reject({ status: 404, message: "Stage not found" });
+      }
+    }
+
+    return new StageDTO(stage);
+  } catch (error) {
+    console.error("Error fetching stage:", error);
+    return Promise.reject(error);
+  }
+};
+
+/**
+ * Create a new stage.
+ * Only Admins and Managers can create stages.
+ * @param {Object} user - The user creating the stage.
+ * @param {Object} data - The stage data.
+ * @returns {Promise<StageDTO>} - The created stage data transfer object.
+ */
+export const createStageService = async (user, data) => {
+  try {
+    if (!["ROLE_ADMIN", "ROLE_MANAGER"].includes(user.role)) {
+      return Promise.reject({
+        status: 403,
+        message: "Access denied: Only admins and managers can create stages",
+      });
+    }
+
+    const stageData = {
+      ...data,
+      name: data.name.toLowerCase(),
+    };
+
+    const newStage = await prisma.stage.create({
+      data: stageData,
+      include: { tasks: true, Project: true },
+    });
+
+    return new StageDTO(newStage);
+  } catch (error) {
+    console.error("Error creating stage:", error);
+    if (error.code === "P2002") {
+      return Promise.reject({
+        status: 409,
+        message: "A stage with this name already exists for this project",
+      });
+    }
+    return Promise.reject({ status: 500, message: "Internal server error" });
+  }
+};
+
+/**
+ * Fully update a stage.
+ * - Admins can update all stages.
+ * - Managers can update stages if they are the project's manager or creator.
+ * @param {Object} user - The user updating the stage.
+ * @param {string} id - The stage ID.
+ * @param {Object} data - The updated stage data.
+ * @returns {Promise<StageDTO>} - The updated stage data transfer object.
+ */
+export const updateStageService = async (user, id, data) => {
+  try {
+    const logConfig = {
+      adminLog: "Admin updating stage: {id}",
+      managerLog: "Manager updating stage they manage or created: {id}",
+      unauthorizedLog: "Access denied: User not authorized to update stage {id}",
+      unauthorizedMessage: "Access denied: You do not have permission to update this stage",
+    };
+
+    await authorizeStageModification(user, id, logConfig);
+
+    const updateData = { ...data };
+    if (updateData.name) updateData.name = updateData.name.toLowerCase();
+
+    const updatedStage = await prisma.stage.update({
+      where: { id },
+      data: updateData,
+      include: { tasks: true, Project: true },
+    });
+
+    return new StageDTO(updatedStage);
+  } catch (error) {
+    console.error("Error updating stage:", error);
+    if (error && error.status) {
+      return Promise.reject(error);
+    }
+    if (error.code === "P2002") {
+      return Promise.reject({
+        status: 409,
+        message: "A stage with this name already exists for this project",
+      });
+    }
+    return Promise.reject({ status: 500, message: "Internal server error" });
+  }
+};
+
+/**
+ * Partially update a stage.
+ * - Admins can update all stages.
+ * - Managers can update a stage if they are the project's manager or creator.
+ * @param {Object} user - The user updating the stage.
+ * @param {string} id - The stage ID.
+ * @param {Object} data - The partial stage data to update.
+ * @returns {Promise<StageDTO>} - The updated stage data transfer object.
+ */
+export const patchStageService = async (user, id, data) => {
+  try {
+    const logConfig = {
+      adminLog: "Admin updating stage: {id}",
+      managerLog: "Manager updating stage they manage or created: {id}",
+      unauthorizedLog: "Access denied: User not authorized to update stage {id}",
+      unauthorizedMessage: "Access denied: You do not have permission to update this stage",
+    };
+
+    await authorizeStageModification(user, id, logConfig);
+
+    const updateData = {};
+    Object.entries(data).forEach(([key, value]) => {
+      if (value !== undefined) updateData[key] = value;
+    });
+
+    if (Object.keys(updateData).length === 0) {
+      return Promise.reject({
+        status: 400,
+        message: "No valid fields provided for update",
+      });
+    }
+
+    if (updateData.name) {
+      updateData.name = updateData.name.toLowerCase();
+    }
+
+    const updatedStage = await prisma.stage.update({
+      where: { id },
+      data: updateData,
+      include: { tasks: true, Project: true },
+    });
+
+    return new StageDTO(updatedStage);
+  } catch (error) {
+    console.error("Error updating stage:", error);
+    if (error && error.status) {
+      return Promise.reject(error);
+    }
+    if (error.code === "P2002") {
+      return Promise.reject({
+        status: 409,
+        message: "A stage with this name already exists for this project",
+      });
+    }
+    return Promise.reject({ status: 500, message: "Internal server error" });
+  }
+};
+
+/**
+ * Delete a stage.
+ * - Admins can delete any stage.
+ * - Managers can delete a stage only if they are the creator of the associated project.
+ * @param {Object} user - The user deleting the stage.
+ * @param {string} id - The stage ID.
+ * @returns {Promise<Object>} - An object with status and a success message.
+ */
+export const deleteStageService = async (user, id) => {
+  try {
+    await authorizeStageDeletion(user, id);
+    await prisma.stage.delete({ where: { id } });
+    return { status: 200, message: "Stage deleted successfully" };
+  } catch (error) {
+    console.error("Error deleting stage:", error);
+    if (error && error.status) {
+      return Promise.reject(error);
+    }
+    return Promise.reject({ status: 500, message: "Internal server error" });
+  }
+};

--- a/services/project-service/tests/unit/controllers/stage.controller.test.js
+++ b/services/project-service/tests/unit/controllers/stage.controller.test.js
@@ -13,6 +13,7 @@ import {
 jest.mock("../../../services/stage.service.js");
 
 describe("🛠 Stage Controller Tests", () => {
+  // eslint-disable-next-line no-unused-vars
   let req, res, next;
   const mockStage = {
     id: "111e2227-e33b-44d3-a555-526614174000",

--- a/services/project-service/tests/unit/services/stage.service.test.js
+++ b/services/project-service/tests/unit/services/stage.service.test.js
@@ -1,0 +1,586 @@
+// tests/unit/services/stage.service.test.js
+jest.mock("../../../config/database.js", () => ({
+    prisma: {
+      stage: {
+        findMany: jest.fn(),
+        count: jest.fn(),
+        findUnique: jest.fn(),
+        findFirst: jest.fn(),
+        create: jest.fn(),
+        update: jest.fn(),
+        delete: jest.fn(),
+      },
+    },
+  }));
+  
+  import { prisma } from "../../../config/database.js";
+  import {
+    getStagesService,
+    getStageByIdService,
+    createStageService,
+    updateStageService,
+    patchStageService,
+    deleteStageService,
+  } from "../../../services/stage.service.js";
+  import { StageDTO } from "../../../dtos/stage.dto.js";
+  
+  describe("🛠 Stage Service Tests", () => {
+    let adminUser, managerUser, employeeUser;
+    let mockStage;
+    let query;
+  
+    beforeEach(() => {
+      adminUser = { id: "admin-id", role: "ROLE_ADMIN" };
+      managerUser = { id: "manager-id", role: "ROLE_MANAGER" };
+      employeeUser = { id: "employee-id", role: "ROLE_EMPLOYEE" };
+  
+      // Example Stage
+      mockStage = {
+        id: "stage-1234",
+        name: "Planning",
+        position: 1,
+        color: "blue",
+        projectId: "project-xyz",
+        createdAt: new Date("2025-02-01T12:00:00.000Z"),
+        updatedAt: new Date("2025-02-02T12:00:00.000Z"),
+        tasks: [],
+        Project: {
+          id: "project-xyz",
+          name: "Sample Project",
+          createdBy: "manager-id",
+          managerId: "manager-id",
+          employeeIds: ["employee-id"],
+        },
+      };
+  
+      query = {};
+  
+      jest.clearAllMocks();
+    });
+  
+    //
+    // ─────────────────────────────────────────────────────────────────────
+    //   ::::: GET STAGES SERVICE TESTS :::::
+    // ─────────────────────────────────────────────────────────────────────
+    //
+    describe("getStagesService", () => {
+      test("✅ returns stages successfully with pagination (page=1, limit=10 default)", async () => {
+        prisma.stage.findMany.mockResolvedValue([mockStage]);
+        prisma.stage.count.mockResolvedValue(1);
+  
+        const result = await getStagesService(adminUser, query);
+        expect(result).toEqual({
+          data: [new StageDTO(mockStage)],
+          page: 1,
+          limit: 10,
+          totalCount: 1,
+          totalPages: 1,
+        });
+      });
+  
+      test("✅ returns empty data when no stages found", async () => {
+        prisma.stage.findMany.mockResolvedValue([]);
+        prisma.stage.count.mockResolvedValue(0);
+  
+        const result = await getStagesService(adminUser, query);
+        expect(result).toEqual({
+          data: [],
+          page: 1,
+          limit: 10,
+          totalCount: 0,
+          totalPages: 0,
+        });
+      });
+  
+      test("✅ applies dynamic filters (e.g., name, position, color, projectId)", async () => {
+        prisma.stage.findMany.mockResolvedValue([mockStage]);
+        prisma.stage.count.mockResolvedValue(1);
+  
+        const customQuery = {
+          name: "planning",
+          position: "1",
+          color: "blue",
+          projectId: "project-xyz",
+        };
+        await getStagesService(adminUser, customQuery);
+  
+        expect(prisma.stage.findMany).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: expect.objectContaining({
+              name: { contains: "planning", mode: "insensitive" },
+              position: 1,
+              color: { equals: "blue" },
+              projectId: "project-xyz",
+            }),
+          })
+        );
+      });
+  
+      test("✅ applies sortField and sortOrder correctly", async () => {
+        prisma.stage.findMany.mockResolvedValue([mockStage]);
+        prisma.stage.count.mockResolvedValue(1);
+  
+        const customQuery = { sortField: "position", sortOrder: "asc" };
+        await getStagesService(adminUser, customQuery);
+  
+        expect(prisma.stage.findMany).toHaveBeenCalledWith(
+          expect.objectContaining({
+            orderBy: { position: "asc" },
+          })
+        );
+      });
+  
+      test("✅ defaults to createdAt desc if invalid sortField and sortOrder", async () => {
+        prisma.stage.findMany.mockResolvedValue([mockStage]);
+        prisma.stage.count.mockResolvedValue(1);
+  
+        const invalidQuery = { sortField: "invalidField", sortOrder: "invalidOrder" };
+        await getStagesService(adminUser, invalidQuery);
+  
+        expect(prisma.stage.findMany).toHaveBeenCalledWith(
+          expect.objectContaining({
+            orderBy: { createdAt: "desc" },
+          })
+        );
+      });
+  
+      test("🚫 rejects with 403 when error code is P2025 (access denied)", async () => {
+        prisma.stage.findMany.mockRejectedValue({ code: "P2025" });
+  
+        await expect(getStagesService(adminUser, query)).rejects.toEqual({
+          status: 403,
+          message: "Access denied: You do not have permission to view stages",
+        });
+      });
+  
+      test("🚫 rejects with 500 on generic error", async () => {
+        prisma.stage.findMany.mockRejectedValue(new Error("Database error"));
+  
+        await expect(getStagesService(adminUser, query)).rejects.toEqual({
+          status: 500,
+          message: "Internal server error",
+        });
+      });
+  
+      test("✅ enforces role-based filter for ROLE_EMPLOYEE", async () => {
+        prisma.stage.findMany.mockResolvedValue([mockStage]);
+        prisma.stage.count.mockResolvedValue(1);
+  
+        await getStagesService(employeeUser, {});
+        expect(prisma.stage.findMany).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: {
+              Project: { employeeIds: { has: "employee-id" } },
+            },
+          })
+        );
+      });
+  
+      test("✅ enforces role-based filter for ROLE_MANAGER", async () => {
+        prisma.stage.findMany.mockResolvedValue([mockStage]);
+        prisma.stage.count.mockResolvedValue(1);
+  
+        await getStagesService(managerUser, {});
+        // Manager filter is an OR condition:
+        expect(prisma.stage.findMany).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: {
+              OR: [
+                { Project: { managerId: "manager-id" } },
+                { Project: { createdBy: "manager-id" } },
+                { Project: { employeeIds: { has: "manager-id" } } },
+              ],
+            },
+          })
+        );
+      });
+  
+      test("✅ no additional filter for ROLE_ADMIN", async () => {
+        prisma.stage.findMany.mockResolvedValue([mockStage]);
+        prisma.stage.count.mockResolvedValue(1);
+  
+        await getStagesService(adminUser, {});
+        // For admin, the role-based filter is an empty object.
+        expect(prisma.stage.findMany).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: {},
+          })
+        );
+      });
+  
+      test("✅ uses provided page/limit if valid numbers", async () => {
+        prisma.stage.findMany.mockResolvedValue([mockStage]);
+        prisma.stage.count.mockResolvedValue(1);
+  
+        const customQuery = { page: "2", limit: "5" };
+        const result = await getStagesService(adminUser, customQuery);
+  
+        expect(result.page).toBe(2);
+        expect(result.limit).toBe(5);
+        expect(prisma.stage.findMany).toHaveBeenCalledWith(
+          expect.objectContaining({
+            skip: 5, // page=2, limit=5 => skip=5
+            take: 5,
+          })
+        );
+      });
+    });
+  
+    //
+    // ─────────────────────────────────────────────────────────────────────
+    //   ::::: GET STAGE BY ID SERVICE TESTS :::::
+    // ─────────────────────────────────────────────────────────────────────
+    //
+    describe("getStageByIdService", () => {
+      test("✅ returns stage successfully if found with user role filter", async () => {
+        prisma.stage.findFirst.mockResolvedValue(mockStage);
+        const result = await getStageByIdService(adminUser, mockStage.id);
+  
+        expect(result).toEqual(new StageDTO(mockStage));
+        expect(prisma.stage.findFirst).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: expect.objectContaining({ id: mockStage.id }),
+          })
+        );
+      });
+  
+      test("🚫 rejects with 403 if stage exists in DB but not returned by findFirst (access denied)", async () => {
+        prisma.stage.findFirst.mockResolvedValue(null);
+        // But stage truly exists (just user doesn't have permission):
+        prisma.stage.findUnique.mockResolvedValue({ id: mockStage.id });
+  
+        await expect(getStageByIdService(employeeUser, mockStage.id)).rejects.toEqual({
+          status: 403,
+          message: "Access denied: You do not have permission to view this stage",
+        });
+      });
+  
+      test("🚫 rejects with 404 if stage doesn't exist at all", async () => {
+        prisma.stage.findFirst.mockResolvedValue(null);
+        prisma.stage.findUnique.mockResolvedValue(null);
+  
+        await expect(getStageByIdService(adminUser, "does-not-exist")).rejects.toEqual({
+          status: 404,
+          message: "Stage not found",
+        });
+      });
+  
+      test("🚫 rejects with original error if thrown by prisma", async () => {
+        const error = new Error("Database error");
+        prisma.stage.findFirst.mockRejectedValue(error);
+  
+        await expect(getStageByIdService(adminUser, mockStage.id)).rejects.toEqual(error);
+      });
+    });
+  
+    //
+    // ─────────────────────────────────────────────────────────────────────
+    //   ::::: CREATE STAGE SERVICE TESTS :::::
+    // ─────────────────────────────────────────────────────────────────────
+    //
+    describe("createStageService", () => {
+      test("🚫 rejects with 403 if user is neither ADMIN nor MANAGER", async () => {
+        await expect(createStageService(employeeUser, { name: "Test" })).rejects.toEqual({
+          status: 403,
+          message: "Access denied: Only admins and managers can create stages",
+        });
+      });
+  
+      test("✅ creates stage successfully, converts name to lowercase", async () => {
+        prisma.stage.create.mockResolvedValue(mockStage);
+  
+        const inputData = { name: "PLANNING", position: 1, projectId: "project-xyz" };
+        const result = await createStageService(adminUser, inputData);
+  
+        expect(prisma.stage.create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            data: { name: "planning", position: 1, projectId: "project-xyz" },
+          })
+        );
+        expect(result).toEqual(new StageDTO(mockStage));
+      });
+  
+      test("🚫 rejects with 409 when error.code === P2002 (duplicate name in same project)", async () => {
+        prisma.stage.create.mockRejectedValue({ code: "P2002" });
+  
+        await expect(createStageService(adminUser, { name: "Duplicate" })).rejects.toEqual({
+          status: 409,
+          message: "A stage with this name already exists for this project",
+        });
+      });
+  
+      test("🚫 rejects with 500 on generic error", async () => {
+        prisma.stage.create.mockRejectedValue(new Error("Database error"));
+  
+        await expect(createStageService(adminUser, { name: "X" })).rejects.toEqual({
+          status: 500,
+          message: "Internal server error",
+        });
+      });
+    });
+  
+    //
+    // ─────────────────────────────────────────────────────────────────────
+    //   ::::: UPDATE STAGE SERVICE TESTS :::::
+    // ─────────────────────────────────────────────────────────────────────
+    //
+    describe("updateStageService", () => {
+      beforeEach(() => {
+        // The service calls authorizeStageModification => prisma.stage.findUnique
+        // We'll simulate that the stage is found and the user is authorized.
+        prisma.stage.findUnique.mockResolvedValue(mockStage);
+        prisma.stage.update.mockResolvedValue({
+          ...mockStage,
+          name: "planning-updated",
+        });
+      });
+  
+      test("✅ updates stage successfully (ADMIN)", async () => {
+        const result = await updateStageService(adminUser, mockStage.id, { name: "PLANNING-UPDATED" });
+        expect(prisma.stage.update).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: { id: mockStage.id },
+            data: { name: "planning-updated" }, // Lowercased
+          })
+        );
+        expect(result).toEqual(new StageDTO({ ...mockStage, name: "planning-updated" }));
+      });
+  
+      test("🚫 rejects if authorizeStageModification fails (manager not matching project creator/manager)", async () => {
+        // If the user is manager but not managerId or createdBy, we must fail with 403.
+        prisma.stage.findUnique.mockResolvedValue({
+          ...mockStage,
+          Project: { ...mockStage.Project, managerId: "someone-else", createdBy: "someone-else" },
+        });
+  
+        await expect(updateStageService(managerUser, mockStage.id, { name: "X" })).rejects.toEqual({
+          status: 403,
+          message: "Access denied: You do not have permission to update this stage",
+        });
+      });
+  
+      test("🚫 rejects with 409 when error.code === P2002 (duplicate name in project)", async () => {
+        prisma.stage.update.mockRejectedValue({ code: "P2002" });
+  
+        await expect(updateStageService(adminUser, mockStage.id, { name: "Conflict" })).rejects.toEqual({
+          status: 409,
+          message: "A stage with this name already exists for this project",
+        });
+      });
+  
+      test("🚫 rejects with custom error if error.status is set (e.g., from authorizeStageModification)", async () => {
+        const customError = { status: 404, message: "Stage not found" };
+        prisma.stage.update.mockRejectedValue(customError);
+  
+        await expect(updateStageService(adminUser, mockStage.id, { name: "Any" })).rejects.toEqual(customError);
+      });
+  
+      test("🚫 rejects with 500 on generic error", async () => {
+        const error = new Error("Database error");
+        prisma.stage.update.mockRejectedValue(error);
+  
+        await expect(updateStageService(adminUser, mockStage.id, { name: "Fail" })).rejects.toEqual({
+          status: 500,
+          message: "Internal server error",
+        });
+      });
+  
+      test("✅ does not modify name if not provided", async () => {
+        await updateStageService(adminUser, mockStage.id, { color: "red" });
+        expect(prisma.stage.update).toHaveBeenCalledWith(
+          expect.objectContaining({
+            data: { color: "red" },
+          })
+        );
+      });
+    });
+  
+    //
+    // ─────────────────────────────────────────────────────────────────────
+    //   ::::: PATCH STAGE SERVICE TESTS :::::
+    // ─────────────────────────────────────────────────────────────────────
+    //
+    describe("patchStageService", () => {
+      beforeEach(() => {
+        prisma.stage.findUnique.mockResolvedValue(mockStage);
+        prisma.stage.update.mockResolvedValue({
+          ...mockStage,
+          color: "green",
+        });
+      });
+  
+      test("✅ patches stage successfully, ignoring undefined fields, lowercasing name if present", async () => {
+        // We only lowerCase 'name' in the service code.
+        // 'color' remains whatever was passed in (e.g. "GREEN").
+      
+        const partialData = { color: "GREEN", position: undefined };
+        const patchedStage = { ...mockStage, color: "green" };
+      
+        const result = await patchStageService(adminUser, mockStage.id, partialData);
+      
+        // We expect Prisma to get exactly "GREEN" for color since the code does not alter it.
+        expect(prisma.stage.update).toHaveBeenCalledWith({
+          where: { id: mockStage.id },
+          data: { color: "GREEN" }, // position is omitted since it's undefined
+          include: { tasks: true, Project: true },
+        });
+      
+        // The final returned StageDTO also has "GREEN" for color.
+        expect(result).toEqual(new StageDTO(patchedStage));
+      });
+      
+  
+      test("🚫 rejects with 400 if no valid fields provided", async () => {
+        await expect(patchStageService(adminUser, mockStage.id, {})).rejects.toEqual({
+          status: 400,
+          message: "No valid fields provided for update",
+        });
+      });
+  
+      test("🚫 rejects with 409 when error.code === P2002 (duplicate name)", async () => {
+        prisma.stage.update.mockRejectedValue({ code: "P2002" });
+  
+        await expect(patchStageService(adminUser, mockStage.id, { name: "Duplicate" })).rejects.toEqual({
+          status: 409,
+          message: "A stage with this name already exists for this project",
+        });
+      });
+  
+      test("🚫 rejects with custom error if error.status is set", async () => {
+        const customError = { status: 404, message: "Stage not found" };
+        prisma.stage.update.mockRejectedValue(customError);
+  
+        await expect(patchStageService(adminUser, mockStage.id, { color: "blue" })).rejects.toEqual(customError);
+      });
+  
+      test("🚫 rejects with 500 on generic error", async () => {
+        prisma.stage.update.mockRejectedValue(new Error("DB error"));
+  
+        await expect(patchStageService(adminUser, mockStage.id, { color: "blue" })).rejects.toEqual({
+          status: 500,
+          message: "Internal server error",
+        });
+      });
+    });
+  
+    //
+    // ─────────────────────────────────────────────────────────────────────
+    //   ::::: DELETE STAGE SERVICE TESTS :::::
+    // ─────────────────────────────────────────────────────────────────────
+    //
+    describe("deleteStageService", () => {
+      test("✅ deletes stage successfully if authorized (ADMIN or manager who created project)", async () => {
+        // authorizeStageDeletion => stage.findUnique => returns something => authorized => do delete
+        prisma.stage.findUnique.mockResolvedValue(mockStage);
+        prisma.stage.delete.mockResolvedValue(mockStage);
+  
+        const result = await deleteStageService(adminUser, mockStage.id);
+        expect(prisma.stage.delete).toHaveBeenCalledWith({ where: { id: mockStage.id } });
+        expect(result).toEqual({ status: 200, message: "Stage deleted successfully" });
+      });
+  
+      test("🚫 rejects with 403 if user not authorized to delete", async () => {
+        // If manager didn't create the project
+        prisma.stage.findUnique.mockResolvedValue({
+          ...mockStage,
+          Project: { ...mockStage.Project, createdBy: "another-user" },
+        });
+  
+        await expect(deleteStageService(managerUser, mockStage.id)).rejects.toEqual({
+          status: 403,
+          message: "Access denied: You do not have permission to delete this stage",
+        });
+      });
+  
+      test("🚫 rejects with custom error (e.g., 404 Stage not found)", async () => {
+        prisma.stage.findUnique.mockResolvedValue(null);
+  
+        await expect(deleteStageService(adminUser, "missing-stage")).rejects.toEqual({
+          status: 404,
+          message: "Stage not found",
+        });
+      });
+  
+      test("🚫 rejects with 500 on generic error", async () => {
+        prisma.stage.findUnique.mockResolvedValue(mockStage);
+        prisma.stage.delete.mockRejectedValue(new Error("DB error"));
+  
+        await expect(deleteStageService(adminUser, mockStage.id)).rejects.toEqual({
+          status: 500,
+          message: "Internal server error",
+        });
+      });
+    });
+    describe("Additional Branch Coverage", () => {
+        test("🚫 rejects with 404 if stage is not found for update", async () => {
+            // Simulate 'authorizeStageModification' returning null from prisma.stage.findUnique
+            prisma.stage.findUnique.mockResolvedValue(null);
+          
+            await expect(
+              updateStageService(managerUser, "non-existent-stage-id", { name: "Anything" })
+            ).rejects.toEqual({
+              status: 404,
+              message: "Stage not found",
+            });
+          });
+
+          test("✅ allows update when managerUser is the manager of the project", async () => {
+            prisma.stage.findUnique.mockResolvedValue({
+              ...mockStage,
+              Project: {
+                ...mockStage.Project,
+                // Make sure 'manager-id' matches the managerUser object
+                managerId: "manager-id",
+                createdBy: "some-other-user",
+              },
+            });
+            prisma.stage.update.mockResolvedValue({ ...mockStage, name: "manager updated" });
+          
+            const result = await updateStageService(managerUser, mockStage.id, { name: "manager updated" });
+          
+            expect(result).toEqual(new StageDTO({ ...mockStage, name: "manager updated" }));
+            expect(prisma.stage.update).toHaveBeenCalledWith(
+              expect.objectContaining({
+                where: { id: mockStage.id },
+                data: { name: "manager updated" },
+              })
+            );
+          });
+          
+          test("✅ allows update when managerUser is the creator of the project", async () => {
+            prisma.stage.findUnique.mockResolvedValue({
+              ...mockStage,
+              Project: {
+                ...mockStage.Project,
+                managerId: "another-manager",
+                createdBy: "manager-id", // managerUser's ID
+              },
+            });
+            prisma.stage.update.mockResolvedValue({ ...mockStage, name: "manager updated" });
+          
+            const result = await updateStageService(managerUser, mockStage.id, { name: "manager updated" });
+          
+            expect(result).toEqual(new StageDTO({ ...mockStage, name: "manager updated" }));
+          });
+          
+
+          test("✅ allows deletion when managerUser is the project creator", async () => {
+            prisma.stage.findUnique.mockResolvedValue({
+              ...mockStage,
+              Project: {
+                ...mockStage.Project,
+                createdBy: "manager-id", // matches managerUser.id
+                managerId: "some-other-manager",
+              },
+            });
+            prisma.stage.delete.mockResolvedValue(mockStage);
+          
+            const result = await deleteStageService(managerUser, mockStage.id);
+          
+            expect(prisma.stage.delete).toHaveBeenCalledWith({ where: { id: mockStage.id } });
+            expect(result).toEqual({ status: 200, message: "Stage deleted successfully" });
+          });
+          
+      });
+  });
+  


### PR DESCRIPTION
# 🚀 Pull Request

## 🔄 Changes
- Refactored stage.service.js and stage.controller.js to align with our Project module patterns.
- Implemented role-based access control for stages:
  - **ROLE_ADMIN:** Can perform all operations.
  - **ROLE_MANAGER:** 
    - Can view stages if associated with projects where they are manager, creator, or assigned.
    - Can update/patch stages only if they are the project's manager or creator.
    - Can delete stages only if they are the creator of the associated project.
  - **ROLE_EMPLOYEE:** Can only view stages for projects where they are assigned.
- Improved error handling across the Stage module, ensuring proper status codes (403, 404, 409, 500) are returned.
- Updated Swagger documentation in stage.routes.js to reflect the new behavior and restrictions.
- Added/updated unit tests for stage.controller.js to achieve 100% coverage, ensuring all routes and error paths are properly tested.

## ✅ Checklist
- [x] Code is properly formatted and linted (`npm run lint`)
- [x] All tests pass 90% - 100% (`npm test:coverage`)
- [x] Added/updated necessary documentation
- [x] No console errors in tests
- [x] Ready for review and merge

