### PR TITLE
Enhance Project Service: Fetch and Enrich User Details from Identity Service

### DIFF
--- a/services/project-service/controllers/project.controller.js
+++ b/services/project-service/controllers/project.controller.js
@@ -42,7 +42,7 @@ export const getProjects = async (req, res) => {
  */
 export const getProjectById = async (req, res) => {
   try {
-    const project = await getProjectByIdService(req.user, req.params.id);
+    const project = await getProjectByIdService(req.user, req.params.id, req.headers.authorization.split(" ")[1]);
     if (!project) return res.status(404).json({ error: "Project not found" });
     res.status(200).json(project);
   } catch (error) {
@@ -62,7 +62,7 @@ export const createProject = [
   validateRequest,
   async (req, res) => {
     try {
-      const project = await createProjectService(req.user, req.body);
+      const project = await createProjectService(req.user, req.body, req.headers.authorization.split(" ")[1]);
       res.status(201).json(project);
     } catch (error) {
       console.error("❌ Error creating project:", error);
@@ -82,7 +82,7 @@ export const updateProject = [
   validateRequest,
   async (req, res) => {
     try {
-      const project = await updateProjectService(req.user, req.params.id, req.body);
+      const project = await updateProjectService(req.user, req.params.id, req.body, req.headers.authorization.split(" ")[1]);
       res.status(200).json(project);
     } catch (error) {
       console.error("❌ Error updating project:", error);
@@ -102,7 +102,7 @@ export const patchProject = [
   validateRequest,
   async (req, res) => {
     try {
-      const project = await patchProjectService(req.user, req.params.id, req.body);
+      const project = await patchProjectService(req.user, req.params.id, req.body, req.headers.authorization.split(" ")[1]);
       res.status(200).json(project);
     } catch (error) {
       console.error("❌ Error patching project:", error);

--- a/services/project-service/dtos/project.dto.js
+++ b/services/project-service/dtos/project.dto.js
@@ -10,8 +10,8 @@ export class ProjectDTO {
     this.createdAt = project.createdAt;
     this.updatedAt = project.updatedAt;
     this.createdBy = project.createdBy;
-    this.managerId = project.managerId;
-    this.employeeIds = project.employeeIds;
+    this.manager = project.manager;
+    this.employees = project.employees;
     this.stages = project.stages
       ? project.stages.map((stage) => new StageDTO(stage))
       : [];

--- a/services/project-service/tests/unit/dtos/project.dto.test.js
+++ b/services/project-service/tests/unit/dtos/project.dto.test.js
@@ -2,59 +2,65 @@ import { ProjectDTO } from "../../../dtos/project.dto.js";
 import { StageDTO } from "../../../dtos/stage.dto.js";
 
 describe("✅ ProjectDTO Tests", () => {
-  const projectData = {
+  // Use enriched user objects in test data
+  const enrichedProjectData = {
     id: "123e4567-e89b-12d3-a456-426614174000",
     name: "WorkNest Platform",
     description: "A project management platform",
     image: "https://example.com/project-image.png",
     documents: ["https://example.com/doc1.pdf"],
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    createdBy: "user-id-1",
-    managerId: "manager-id-1",
-    employeeIds: ["employee-1", "employee-2"],
+    createdAt: new Date("2025-02-01T12:00:00.000Z"),
+    updatedAt: new Date("2025-02-02T12:00:00.000Z"),
+    createdBy: { id: "user-id-1", fullName: "Test Creator", role: "ROLE_ADMIN" },
+    manager: { id: "manager-id-1", fullName: "Test Manager", role: "ROLE_MANAGER" },
+    employees: [
+      { id: "employee-1", fullName: "Test Employee 1", role: "ROLE_EMPLOYEE" },
+      { id: "employee-2", fullName: "Test Employee 2", role: "ROLE_EMPLOYEE" },
+    ],
     stages: [
       { id: "stage-1", name: "Stage 1" },
       { id: "stage-2", name: "Stage 2" },
-    ], // ✅ Ensures `stages.map(...)` is covered
+    ],
   };
 
-  test("✅ Converts project object to DTO", () => {
-    const dto = new ProjectDTO(projectData);
+  test("✅ Converts enriched project object to ProjectDTO", () => {
+    const dto = new ProjectDTO(enrichedProjectData);
 
     expect(dto).toEqual({
-      id: projectData.id,
-      name: projectData.name,
-      description: projectData.description,
-      image: projectData.image,
-      documents: projectData.documents,
-      createdAt: projectData.createdAt,
-      updatedAt: projectData.updatedAt,
-      createdBy: projectData.createdBy,
-      managerId: projectData.managerId,
-      employeeIds: projectData.employeeIds,
-      stages: projectData.stages.map((stage) => new StageDTO(stage)), // ✅ Ensures StageDTO mapping
+      id: enrichedProjectData.id,
+      name: enrichedProjectData.name,
+      description: enrichedProjectData.description,
+      image: enrichedProjectData.image,
+      documents: enrichedProjectData.documents,
+      createdAt: enrichedProjectData.createdAt,
+      updatedAt: enrichedProjectData.updatedAt,
+      createdBy: enrichedProjectData.createdBy,
+      manager: enrichedProjectData.manager,
+      employees: enrichedProjectData.employees,
+      stages: enrichedProjectData.stages.map((stage) => new StageDTO(stage)),
     });
   });
 
   test("✅ Handles missing stages property", () => {
-    const dto = new ProjectDTO({ ...projectData, stages: undefined }); // ✅ Ensures empty array case
+    const input = { ...enrichedProjectData, stages: undefined };
+    const dto = new ProjectDTO(input);
 
-    expect(dto.stages).toEqual([]); // ✅ Ensures the default empty array behavior
+    expect(dto.stages).toEqual([]);
   });
 
-  test("✅ Handles empty documents array", () => {
-    const dto = new ProjectDTO({ ...projectData, documents: undefined });
+  test("✅ Handles missing documents property", () => {
+    const input = { ...enrichedProjectData, documents: undefined };
+    const dto = new ProjectDTO(input);
 
-    expect(dto.documents).toEqual(undefined); // ✅ Ensures documents can be undefined
+    expect(dto.documents).toEqual(undefined);
   });
 
   test("✅ Handles missing optional fields", () => {
     const minimalProjectData = {
       id: "456e7890-e12d-34a5-b678-910111213000",
       name: "Minimal Project",
-      createdAt: new Date(),
-      updatedAt: new Date(),
+      createdAt: new Date("2025-02-01T12:00:00.000Z"),
+      updatedAt: new Date("2025-02-01T12:00:00.000Z"),
       stages: [],
     };
 
@@ -69,8 +75,8 @@ describe("✅ ProjectDTO Tests", () => {
       createdAt: minimalProjectData.createdAt,
       updatedAt: minimalProjectData.updatedAt,
       createdBy: undefined,
-      managerId: undefined,
-      employeeIds: undefined,
+      manager: undefined,
+      employees: undefined,
       stages: [],
     });
   });

--- a/services/project-service/validators/project.validator.js
+++ b/services/project-service/validators/project.validator.js
@@ -22,10 +22,8 @@ export const createProjectValidation = [
     .isURL()
     .withMessage("Each document must be a valid URL"),
   body("createdBy")
-    .notEmpty()
-    .withMessage("CreatedBy (User ID) is required")
-    .isString()
-    .withMessage("CreatedBy must be a string"),
+    .not().exists()
+    .withMessage("Cannot set createdBy manually"),
   body("managerId")
     .optional()
     .isString()
@@ -66,6 +64,9 @@ export const updateProjectValidation = [
     .optional()
     .isString()
     .withMessage("Manager ID must be a string"),
+  body("createdBy")
+    .not().exists()
+    .withMessage("Cannot set createdBy manually"),
   body("employeeIds")
     .optional()
     .isArray()
@@ -104,6 +105,9 @@ export const patchProjectValidation = [
     .optional()
     .isString()
     .withMessage("Manager ID must be a string"),
+  body("createdBy")
+    .not().exists()
+    .withMessage("Cannot set createdBy manually"),
   body("employeeIds")
     .optional()
     .isArray()


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Summary
This PR enhances the Project service by improving the user enrichment process. We now fetch and attach user details (manager, creator, and employees) from the identity service for every project operation (get by id, create, update, and patch). This ensures that our DTOs always include up-to-date user information.

- 

## 🔄 Changes
- **User Enrichment:** Added logic to collect unique user IDs from `managerId`, `createdBy`, and `employeeIds` and fetch their details.
- **Branch Coverage:** Added and optimized tests to cover scenarios where these fields are missing, empty, or partially available (fallbacks to `{ id }`).
- **Test Improvements:** Consolidated tests for the Project and Task services to ensure 100% branch coverage for the user enrichment code.


## ✅ Checklist
- [x] Code is properly formatted and linted (`npm run lint`)
- [x] All tests pass 90% - 100% (`npm test:coverage`)
- [x] Added/updated necessary documentation
- [x] No console errors in tests
- [x] Ready for review and merge

## 🔍 Screenshots (if applicable)
<img width="443" alt="image" src="https://github.com/user-attachments/assets/349d2174-7b70-4dd9-b2de-4c087aa3eaca" />
