### PR TITLE
Feature/clean verify email

### DIFF
--- a/services/identity-service/controllers/auth.controller.js
+++ b/services/identity-service/controllers/auth.controller.js
@@ -64,10 +64,9 @@ export const login = [
  */
 export const verifyEmail = async (req, res) => {
   try {
-    const { userId, token } = req.params;
-    const result = await verifyEmailService(userId, token);
+    const { token } = req.params; // Récupérer token depuis req.params
+    const result = await verifyEmailService(token); // Passer seulement token
     if (result.redirect) {
-      // If the service indicates a redirect (common pattern)
       return res.redirect(result.redirect);
     }
     res.status(result.status).json(result.response);
@@ -77,6 +76,7 @@ export const verifyEmail = async (req, res) => {
     res.status(status).json({ error: error.message });
   }
 };
+
 
 /**
  * Controller for requesting a password reset

--- a/services/identity-service/routes/auth.routes.js
+++ b/services/identity-service/routes/auth.routes.js
@@ -92,18 +92,12 @@ router.post("/login", login);
 
 /**
  * @swagger
- * /api/auth/verify-email/{userId}/{token}:
+ * /api/auth/verify-email/{token}:
  *   get:
  *     summary: Verify email
  *     description: Verifies a user's email address using a verification token.
  *     tags: [Authentication]
  *     parameters:
- *       - in: path
- *         name: userId
- *         required: true
- *         schema:
- *           type: string
- *         description: User ID
  *       - in: path
  *         name: token
  *         required: true
@@ -116,7 +110,7 @@ router.post("/login", login);
  *       400:
  *         description: Invalid or expired token.
  */
-router.get("/verify-email/:userId/:token", verifyEmail);
+router.get("/verify-email/:token", verifyEmail);
 
 /**
  * @swagger

--- a/services/identity-service/services/email.service.js
+++ b/services/identity-service/services/email.service.js
@@ -10,7 +10,7 @@ import { sendMail } from "../config/mail.js";
  * @throws Will throw an error if email sending fails.
  */
 export async function sendVerificationEmail(user, verificationToken) {
-  const verifyLink = `${process.env.BASE_URL}/api/auth/verify-email/${user.id}/${verificationToken}`;
+  const verifyLink = `${process.env.BASE_URL}/api/auth/verify-email/${verificationToken}`;
 
   const subject = "Welcome to WorkNest - Verify Your Email";
   const text = `Hello ${user.firstName},\n\nTo verify your email address and activate your account, please click on the following link: ${verifyLink}\n\nIf you did not create this account, please ignore this email.`;

--- a/services/identity-service/tests/unit/controllers/auth.controller.test.js
+++ b/services/identity-service/tests/unit/controllers/auth.controller.test.js
@@ -131,15 +131,15 @@ describe("🧪 Auth Controller Tests", () => {
         redirect: "http://frontend/login",
         response: { message: "Email verified" },
       });
-
-      req.params = { userId: "user-123", token: "verify-token" };
-
+    
+      req.params = { token: "verify-token" };
+    
       await authController.verifyEmail(req, res);
-
-      expect(verifyEmailService).toHaveBeenCalledWith("user-123", "verify-token");
-      // Because result.redirect was set, we expect res.redirect
+    
+      expect(verifyEmailService).toHaveBeenCalledWith("verify-token");
       expect(res.redirect).toHaveBeenCalledWith("http://frontend/login");
     });
+    
 
     test("✅ should verify email without redirect, just JSON response", async () => {
       verifyEmailService.mockResolvedValue({

--- a/services/identity-service/tests/unit/services/auth.service.test.js
+++ b/services/identity-service/tests/unit/services/auth.service.test.js
@@ -264,15 +264,17 @@ describe("🧪 Auth Service Tests", () => {
         id: "vtoken-id",
         userId: "user-123",
         token: "verify-token",
-        expiresAt: new Date(mockDateNow + 1000), // not expired
+        expiresAt: new Date(mockDateNow + 1000),
       });
-
+    
       prisma.user.update.mockResolvedValue({ ...mockUser, isVerified: true });
       prisma.verificationToken.delete.mockResolvedValue({});
-
-      const result = await verifyEmailService("user-123", "verify-token");
+    
+      const result = await verifyEmailService("verify-token");
+    
       expect(prisma.verificationToken.findFirst).toHaveBeenCalledWith({
-        where: { userId: "user-123", token: "verify-token" },
+        where: { token: "verify-token" },
+        include: { user: true }, 
       });
       expect(prisma.user.update).toHaveBeenCalledWith({
         where: { id: "user-123" },
@@ -281,9 +283,9 @@ describe("🧪 Auth Service Tests", () => {
       expect(prisma.verificationToken.delete).toHaveBeenCalledWith({
         where: { id: "vtoken-id" },
       });
-      expect(result.status).toBe(302);
-      expect(result.redirect).toContain("login");
+      expect(result.redirect).toContain("/login");
     });
+    
 
     test("🚫 invalid or expired => 400", async () => {
       // no token or expired


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Summary
<!-- Provide a brief description of the changes made in this PR -->
- Refactored the `verifyEmailService` and related components to remove the `userId` parameter from the verification flow. 
- Updated the verification route, controller, and service to work with only the `token` parameter.

## 🔄 Changes
<!-- List the key updates and improvements -->
- **Refactored `verifyEmailService`**: Removed the `userId` parameter and modified it to retrieve the user directly from the token.
- **Updated `verifyEmail` route**: Removed the `userId` parameter from the API route.
- **Modified `verifyEmailController`**: Changed the controller to accept only the `token` parameter and updated the logic to work with the new service signature.
- **Updated `sendVerificationEmail`**: Removed the `userId` from the verification link.
- **Refactored tests**: Adjusted the tests for `verifyEmailController` and `verifyEmailService` to work with the new flow, ensuring that the token alone is passed.

## ✅ Checklist
- [x] Code is properly formatted and linted (`npm run lint`)
- [x] All tests pass 90% - 100% (`npm test:coverage`)
- [x] Added/updated necessary documentation
- [x] No console errors in tests
- [x] Ready for review and merge
